### PR TITLE
Updates output types to be wasm-bindgen::JsValues, rather than strings.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,30 +1,4 @@
 [[package]]
-name = "backtrace"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "backtrace-sys 0.1.24 (registry+https://github.com/rust-lang/crates.io-index)",
- "cfg-if 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-demangle 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "backtrace-sys"
-version = "0.1.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "cc 1.0.25 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "cc"
-version = "1.0.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
 name = "cfg-if"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -44,31 +18,10 @@ version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "failure"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "backtrace 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "failure_derive 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "failure_derive"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "proc-macro2 0.4.20 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.14.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "synstructure 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "ga-v4-flattener"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+version = "0.2.1"
+source = "git+https://github.com/C-Saunders/google_analytics_v4_report_flattener#da61df55efe60f87cf04940dbc6e977bc3c17b53"
 dependencies = [
- "failure 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.7.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -77,10 +30,10 @@ dependencies = [
 
 [[package]]
 name = "google-analytics-v4-report-flattener-wasm"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "console_error_panic_hook 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "ga-v4-flattener 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ga-v4-flattener 0.2.1 (git+https://github.com/C-Saunders/google_analytics_v4_report_flattener)",
  "serde 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.32 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasm-bindgen 0.2.25 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -108,11 +61,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "libc"
-version = "0.2.43"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
 name = "log"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -135,11 +83,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 0.4.20 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
-
-[[package]]
-name = "rustc-demangle"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "ryu"
@@ -173,32 +116,11 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "0.14.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "proc-macro2 0.4.20 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "syn"
 version = "0.15.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 0.4.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "synstructure"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "proc-macro2 0.4.20 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.14.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -217,6 +139,8 @@ name = "wasm-bindgen"
 version = "0.2.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
+ "serde 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.32 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasm-bindgen-macro 0.2.25 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -264,50 +188,22 @@ dependencies = [
  "serde_derive 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
-[[package]]
-name = "winapi"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "winapi-i686-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "winapi-x86_64-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
 [metadata]
-"checksum backtrace 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "89a47830402e9981c5c41223151efcced65a0510c13097c769cede7efb34782a"
-"checksum backtrace-sys 0.1.24 (registry+https://github.com/rust-lang/crates.io-index)" = "c66d56ac8dabd07f6aacdaf633f4b8262f5b3601a810a0dcddffd5c22c69daa0"
-"checksum cc 1.0.25 (registry+https://github.com/rust-lang/crates.io-index)" = "f159dfd43363c4d08055a07703eb7a3406b0dac4d0584d96965a3262db3c9d16"
 "checksum cfg-if 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "0c4e7bb64a8ebb0d856483e1e682ea3422f883c5f5615a90d51a2c82fe87fdd3"
 "checksum console_error_panic_hook 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "6c5dd2c094474ec60a6acaf31780af270275e3153bafff2db5995b715295762e"
 "checksum either 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3be565ca5c557d7f59e7cfcf1844f9e3033650c929c6566f511e8005f205c1d0"
-"checksum failure 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7efb22686e4a466b1ec1a15c2898f91fa9cb340452496dca654032de20ff95b9"
-"checksum failure_derive 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "946d0e98a50d9831f5d589038d2ca7f8f455b1c21028c0db0e84116a12696426"
-"checksum ga-v4-flattener 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "872deda08d542d94e90fa137df6576b3457c373f6542b220c524492c44c41c55"
+"checksum ga-v4-flattener 0.2.1 (git+https://github.com/C-Saunders/google_analytics_v4_report_flattener)" = "<none>"
 "checksum itertools 0.7.8 (registry+https://github.com/rust-lang/crates.io-index)" = "f58856976b776fedd95533137617a02fb25719f40e7d9b01c7043cd65474f450"
 "checksum itoa 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "1306f3464951f30e30d12373d31c79fbd52d236e5e896fd92f96ec7babbbe60b"
 "checksum lazy_static 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ca488b89a5657b0a2ecd45b95609b3e848cf1755da332a0da46e2b2b1cb371a7"
-"checksum libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)" = "76e3a3ef172f1a0b9a9ff0dd1491ae5e6c948b94479a3021819ba7d860c8645d"
 "checksum log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)" = "d4fcce5fa49cc693c312001daf1d13411c4a5283796bac1084299ea3e567113f"
 "checksum proc-macro2 0.4.20 (registry+https://github.com/rust-lang/crates.io-index)" = "3d7b7eaaa90b4a90a932a9ea6666c95a389e424eff347f0f793979289429feee"
 "checksum quote 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)" = "dd636425967c33af890042c483632d33fa7a18f19ad1d7ea72e8998c6ef8dea5"
-"checksum rustc-demangle 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "bcfe5b13211b4d78e5c2cadfebd7769197d95c639c35a50057eb4c05de811395"
 "checksum ryu 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "7153dd96dade874ab973e098cb62fcdbb89a03682e46b144fd09550998d4a4a7"
 "checksum serde 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)" = "15c141fc7027dd265a47c090bf864cf62b42c4d228bbcf4e51a0c9e2b0d3f7ef"
 "checksum serde_derive 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)" = "225de307c6302bec3898c51ca302fc94a7a1697ef0845fcee6448f33c032249c"
 "checksum serde_json 1.0.32 (registry+https://github.com/rust-lang/crates.io-index)" = "43344e7ce05d0d8280c5940cabb4964bea626aa58b1ec0e8c73fa2a8512a38ce"
-"checksum syn 0.14.9 (registry+https://github.com/rust-lang/crates.io-index)" = "261ae9ecaa397c42b960649561949d69311f08eeaea86a65696e6e46517cf741"
 "checksum syn 0.15.11 (registry+https://github.com/rust-lang/crates.io-index)" = "b036b7b35e846707c0e55c2c9441fa47867c0f87fca416921db3261b1d8c741a"
-"checksum synstructure 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "85bb9b7550d063ea184027c9b8c20ac167cd36d3e06b3a40bceb9d746dc1a7b7"
 "checksum unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
 "checksum version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "914b1a6776c4c929a602fafd8bc742e06365d4bcbe48c30f9cca5824f70dc9dd"
 "checksum wasm-bindgen 0.2.25 (registry+https://github.com/rust-lang/crates.io-index)" = "f311aadd18256d877892bec29178d70f5c19788ecbe6c48a9a7f2577b95dcc01"
@@ -315,6 +211,3 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum wasm-bindgen-macro 0.2.25 (registry+https://github.com/rust-lang/crates.io-index)" = "4d41d4dad37cc64374a4026f4d7b4f513f83538c14e1633b6566dda5a5c099d9"
 "checksum wasm-bindgen-macro-support 0.2.25 (registry+https://github.com/rust-lang/crates.io-index)" = "b6cf86d2aa910c060fbdb0396ce17cfb5f1a5bcae833bd195cf2b3911f152a90"
 "checksum wasm-bindgen-shared 0.2.25 (registry+https://github.com/rust-lang/crates.io-index)" = "b719b78cb42bd6376de5efd85c991cb8e3fb0cef7adf01e56cec6d8cb9e20470"
-"checksum winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "92c1eb33641e276cfa214a0522acad57be5c56b10cb348b3c5117db75f3ac4b0"
-"checksum winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
-"checksum winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,8 +19,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "ga-v4-flattener"
-version = "0.2.1"
-source = "git+https://github.com/C-Saunders/google_analytics_v4_report_flattener#da61df55efe60f87cf04940dbc6e977bc3c17b53"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "itertools 0.7.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -33,7 +33,7 @@ name = "google-analytics-v4-report-flattener-wasm"
 version = "0.2.0"
 dependencies = [
  "console_error_panic_hook 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "ga-v4-flattener 0.2.1 (git+https://github.com/C-Saunders/google_analytics_v4_report_flattener)",
+ "ga-v4-flattener 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.32 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasm-bindgen 0.2.25 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -192,7 +192,7 @@ dependencies = [
 "checksum cfg-if 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "0c4e7bb64a8ebb0d856483e1e682ea3422f883c5f5615a90d51a2c82fe87fdd3"
 "checksum console_error_panic_hook 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "6c5dd2c094474ec60a6acaf31780af270275e3153bafff2db5995b715295762e"
 "checksum either 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3be565ca5c557d7f59e7cfcf1844f9e3033650c929c6566f511e8005f205c1d0"
-"checksum ga-v4-flattener 0.2.1 (git+https://github.com/C-Saunders/google_analytics_v4_report_flattener)" = "<none>"
+"checksum ga-v4-flattener 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9ce07db6e0e32ee0efe96843ccba1d8042d3883497b49b4b8b7335ed5d16706f"
 "checksum itertools 0.7.8 (registry+https://github.com/rust-lang/crates.io-index)" = "f58856976b776fedd95533137617a02fb25719f40e7d9b01c7043cd65474f450"
 "checksum itoa 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "1306f3464951f30e30d12373d31c79fbd52d236e5e896fd92f96ec7babbbe60b"
 "checksum lazy_static 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ca488b89a5657b0a2ecd45b95609b3e848cf1755da332a0da46e2b2b1cb371a7"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-ga-v4-flattener = { git = "https://github.com/C-Saunders/google_analytics_v4_report_flattener" }
+ga-v4-flattener = "0.3"
 serde = "1.0"
 serde_json = "1.0"
 console_error_panic_hook = "0.1.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "google-analytics-v4-report-flattener-wasm"
-version = "0.1.1"
+version = "0.2.0"
 authors = ["Charlie Saunders <charlieasaunders@gmail.com>"]
 license = "MIT"
 
@@ -8,11 +8,14 @@ license = "MIT"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-ga-v4-flattener = "0.1.1"
+ga-v4-flattener = { git = "https://github.com/C-Saunders/google_analytics_v4_report_flattener" }
 serde = "1.0"
 serde_json = "1.0"
-wasm-bindgen = "0.2"
 console_error_panic_hook = "0.1.1"
+
+[dependencies.wasm-bindgen]
+version = "^0.2"
+features = ["serde-serialize"]
 
 [profile.release]
 # Tell `rustc` to optimize for small code size.

--- a/README.md
+++ b/README.md
@@ -4,27 +4,42 @@ Converts Google Analytics API v4 reports to flat/delimited data.
 
 This is a wrapper around [this Rust package](https://crates.io/crates/ga-v4-flattener) to make it available as a WebAssembly package. Credit to [wasm-pack](https://github.com/rustwasm/wasm-pack) for doing the hard work for the wasm compilation.
 
-### Important Note
-From what I can see, Web Assembly can't return objects right now, so we need to JSON `stringify` and then `parse`, unfortunately.
-
 ## API
 
-### `toDelimited(data: string, delimiter: string): string`
+### `toDelimited(data: string, delimiter: string): Array<string>`
+### `parsedtoFlatJson(data: Array<Report>, delimiter: string): Array<string>`
 ```ts
-const { toDelimited } = require('google-analytics-v4-report-flattener-wasm')
+const { toDelimited, parsedToDelimited } = require('google-analytics-v4-report-flattener-wasm')
 const data = require('./test.json')
 
-JSON.parse(toDelimited(JSON.stringify(data), ","))
+// if you did not parse the response from Google, use this
+// (you wouln't need to stringify first)
+toDelimited(JSON.stringify(data), ',')
+
+// if you parsed the JSON response in JavaScript already
+// for example, if the library does it or you need to inspect it
+parsedToDelimited(data, ',')
+
+// the result is an array in either case, starting with v0.2
 [ '"ga:deviceCategory","ga:sessions","ga:bounces"\n"desktop",25,17\n"mobile",2,2\n',
   '"ga:country","ga:sessions","ga:bounces"\n"Azerbaijan",1,0\n"France",18,11\n"Japan",4,4\n"Switzerland",1,1\n"United States",3,3\n' ]
 ```
 
-### `toFlatJson(data: string): string`
+### `toFlatJson(data: string): Arrray<{ [field: string]: number | string }>`
+### `parsedtoFlatJson(data: Array<Report>): Arrray<{ [field: string]: number | string }>`
 ```ts
-const { toFlatJson } = require('google-analytics-v4-report-flattener-wasm')
+const { toFlatJson, parsedtoFlatJson } = require('google-analytics-v4-report-flattener-wasm')
 const data = require('./test.json')
 
-JSON.parse(toFlatJson(JSON.stringify(data))
+// if you did not parse the response from Google, use this
+// (you wouln't need to stringify first)
+toFlatJson(JSON.stringify(data))
+
+// if you parsed the JSON response in JavaScript already
+// for example, if the library does it or you need to inspect it
+parsedtoFlatJson(data)
+
+// the result is an array in either case, starting with v0.2
 [
   [{
       'ga:bounces': 17,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,12 @@
+extern crate console_error_panic_hook;
 extern crate ga_v4_flattener;
 extern crate serde;
 extern crate serde_json;
 extern crate wasm_bindgen;
-extern crate console_error_panic_hook;
 
+use ga_v4_flattener::to_delimited::response_to_delimited_reports;
+use ga_v4_flattener::to_row_array::response_to_row_array;
+use ga_v4_flattener::types::ReportResponse;
 use ga_v4_flattener::{to_delimited, to_flat_json};
 use wasm_bindgen::prelude::*;
 
@@ -12,17 +15,35 @@ fn set_panic_hook() {
 }
 
 #[wasm_bindgen]
-#[allow(non_snake_case)] 
-pub fn toDelimited(data: &str, delimiter: &str) -> String {
+#[allow(non_snake_case)]
+pub fn toDelimited(data: &str, delimiter: &str) -> JsValue {
     set_panic_hook();
 
-    serde_json::to_string(&to_delimited(data, delimiter).unwrap()).unwrap()
+    JsValue::from_serde(&to_delimited(data, delimiter).unwrap()).unwrap()
 }
 
 #[wasm_bindgen]
-#[allow(non_snake_case)] 
-pub fn toFlatJson(data: &str) -> String {
+#[allow(non_snake_case)]
+pub fn parsedToDelimited(param_data: &JsValue, delimiter: &str) -> JsValue {
     set_panic_hook();
-    
-    serde_json::to_string(&to_flat_json(data).unwrap()).unwrap()
+
+    let data: ReportResponse = param_data.into_serde().unwrap();
+    JsValue::from_serde(&response_to_delimited_reports(&data, delimiter)).unwrap()
+}
+
+#[wasm_bindgen]
+#[allow(non_snake_case)]
+pub fn toFlatJson(data: &str) -> JsValue {
+    set_panic_hook();
+
+    JsValue::from_serde(&to_flat_json(data).unwrap()).unwrap()
+}
+
+#[wasm_bindgen]
+#[allow(non_snake_case)]
+pub fn parsedtoFlatJson(param_data: &JsValue) -> JsValue {
+    set_panic_hook();
+
+    let data: ReportResponse = param_data.into_serde().unwrap();
+    JsValue::from_serde(&response_to_row_array(&data)).unwrap()
 }


### PR DESCRIPTION
**Do not merge until git dependency is removed**

Adds parsedToDelimited and parsedtoFlatJson functions which accept a
parsed report response as their input, rather than a string.

We are using [wasm-bindgen's serde support](https://rustwasm.github.io/wasm-bindgen/reference/arbitrary-data-with-serde.html#serializing-and-deserializing-arbitrary-data-into-and-from-jsvalue-with-serde) to make this work.